### PR TITLE
fix: langgraph build context

### DIFF
--- a/langgraph.json
+++ b/langgraph.json
@@ -1,0 +1,11 @@
+{
+  "node_version": "20",
+  "dockerfile_lines": [],
+  "dependencies": ["./apps/rita"],
+  "graphs": {
+    "rita": "./apps/rita/src/graphs/rita/graph.ts:graph"
+  },
+  "auth": {
+    "path": "apps/rita/src/security/auth.ts:auth"
+  }
+}


### PR DESCRIPTION
Ok so what I'm trying to test here is based on the build error from langgraph side:

I think this simply means that it uses the path of the target langgraph.json as their 'build context', while this was correct before turborepo, I want them to build with the full monorepo context, so it also builds the required packages and uses them. Hoping that moving (currently duplicated but mainly to verify if my logic checks out) that file to the root so the context is in the root as well

```log
01/08/2025, 12:35:34
[INFO] ERROR: build step 14 "langchain/hosted-langgraph-api-build" failed: step exited with non-zero status: 1
01/08/2025, 12:35:34
[INFO] ERROR
01/08/2025, 12:35:34
[INFO] Finished Step #14
01/08/2025, 12:35:33
[INFO] Step #14: RUN (test ! -f /api/langgraph_api/js/build.mts && echo "Prebuild script not found, skipping") || tsx /api/langgraph_api/js/build.mts
01/08/2025, 12:35:33
[INFO] Step #14: WORKDIR /deps/rita
01/08/2025, 12:35:33
[INFO] Step #14: ENV LANGSERVE_GRAPHS='{"rita": "./src/graphs/rita/graph.ts:graph"}'
01/08/2025, 12:35:33
[INFO] Step #14: ENV LANGGRAPH_AUTH='{"path": "src/security/auth.ts:auth"}'
01/08/2025, 12:35:33
[INFO] Step #14: RUN cd /deps/rita && npm ci
01/08/2025, 12:35:33
[INFO] Step #14: ADD . /deps/rita
01/08/2025, 12:35:33
[INFO] Step #14: FROM gcr.io/langchain-prod/langgraphjs-api-unlicensed:20
01/08/2025, 12:35:33
[INFO] Step #14: + docker build -f - -t europe-west4-docker.pkg.dev/langchain-prod/langgraph-cloud-builds/ritagraph-prod-ac7af9d62ac65e87b31b287139d64490:a6a34093-d014-412d-8cad-b66c102f20b8 /workspace/ritagraph/apps/rita <
01/08/2025, 12:35:33
[INFO] Step #14: + docker pull gcr.io/langchain-prod/langgraphjs-api-unlicensed:20
01/08/2025, 12:35:33
[INFO] Step #14: ERROR: failed to build: failed to solve: executor failed running [/bin/sh -c cd /deps/rita && npm ci]: exit code: 1
01/08/2025, 12:35:33
[INFO] Step #14: ------
01/08/2025, 12:35:33
[INFO] Step #14: 7.103 npm error A complete log of this run can be found in: /root/.npm/_logs/2025-08-01T10_35_26_934Z-debug-0.log
01/08/2025, 12:35:33
[INFO] Step #14: 7.103 npm notice
01/08/2025, 12:35:33
[INFO] Step #14: 7.103 npm notice To update run: npm install -g npm@11.5.2
01/08/2025, 12:35:33
[INFO] Step #14: ERROR: failed to build: failed to solve: executor failed running [/bin/sh -c cd /deps/rita && npm ci]: exit code: 1
01/08/2025, 12:35:33
[INFO] Step #14: ------
01/08/2025, 12:35:33
[INFO] Step #14: 7.103 npm error A complete log of this run can be found in: /root/.npm/_logs/2025-08-01T10_35_26_934Z-debug-0.log
01/08/2025, 12:35:33
[INFO] Step #14: 7.103 npm notice
01/08/2025, 12:35:33
[INFO] Step #14: 7.103 npm notice To update run: npm install -g npm@11.5.2
01/08/2025, 12:35:33
[INFO] Step #14: 7.103 npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.5.2
01/08/2025, 12:35:33
[INFO] Step #14: 7.103 npm notice New major version of npm available! 10.8.2 -> 11.5.2
01/08/2025, 12:35:33
[INFO] Step #14: 7.103 npm notice
01/08/2025, 12:35:33
[INFO] Step #14: 7.100 npm error 404 tarball, folder, http url, or git url.
01/08/2025, 12:35:33
[INFO] Step #14: 7.100 npm error 404 Note that you can also install from a
01/08/2025, 12:35:33
[INFO] Step #14: 7.100 npm error 404
01/08/2025, 12:35:33
[INFO] Step #14: 7.100 npm error 404  '@the-project-b/graphql@*' is not in this registry.
01/08/2025, 12:35:33
[INFO] Step #14:  > [3/5] RUN cd /deps/rita && npm ci:
```