### PR TITLE
feat: PRO-6668 - Now using the appdata token between BE -> GRAPH -> BE for more logic consistency

### DIFF
--- a/packages/rita-graphs/src/graphs/rita/graph.ts
+++ b/packages/rita-graphs/src/graphs/rita/graph.ts
@@ -48,6 +48,7 @@ function createFetchTools(getAuthUser: (config: any) => any) {
     const toolContext = {
       accessToken: authUser.token,
       selectedCompanyId: companyId,
+      appdataHeader: authUser.appdataHeader, // Pass appdata header for impersonation
     };
 
     const tools = toolFactory<undefined>({
@@ -119,7 +120,8 @@ export function createRitaGraph(getAuthUser: (config: any) => any) {
     } catch (error) {
       logger.error("Failed to initialize Rita graph", error, {
         operation: "createRitaGraph",
-        errorType: error instanceof Error ? error.constructor.name : "UnknownError",
+        errorType:
+          error instanceof Error ? error.constructor.name : "UnknownError",
         errorMessage: error instanceof Error ? error.message : String(error),
       });
       process.exit(1);
@@ -137,4 +139,4 @@ export const graph = async () => {
   );
 };
 
-console.log("test")
+console.log("test");

--- a/packages/rita-graphs/src/tools/find-employee/tool.ts
+++ b/packages/rita-graphs/src/tools/find-employee/tool.ts
@@ -21,7 +21,7 @@ export const findEmployee = (ctx: ToolContext) =>
         operation: "find_employee",
         companyId: ctx.selectedCompanyId,
       });
-      const client = createGraphQLClient(ctx.accessToken);
+      const client = createGraphQLClient(ctx);
 
       const employees = await Promise.all(
         userNameParts.map((namePart) =>

--- a/packages/rita-graphs/src/tools/get-active-employees-with-contracts/tool.ts
+++ b/packages/rita-graphs/src/tools/get-active-employees-with-contracts/tool.ts
@@ -12,7 +12,10 @@ import {
 import { Result } from "../../utils/types/result";
 import { createLogger } from "@the-project-b/logging";
 
-const logger = createLogger({ service: "rita-graphs" }).child({ module: "Tools", tool: "get_active_employees_with_contracts" });
+const logger = createLogger({ service: "rita-graphs" }).child({
+  module: "Tools",
+  tool: "get_active_employees_with_contracts",
+});
 
 export const getActiveEmployeesWithContracts = (ctx: ToolContext) =>
   tool(
@@ -21,11 +24,11 @@ export const getActiveEmployeesWithContracts = (ctx: ToolContext) =>
         operation: "get_active_employees_with_contracts",
         companyId: ctx.selectedCompanyId,
       });
-      const client = createGraphQLClient(ctx.accessToken);
+      const client = createGraphQLClient(ctx);
 
       const employeesWithContracts = await fetchActiveEmployeesWithContracts(
         client,
-        ctx.selectedCompanyId
+        ctx.selectedCompanyId,
       );
 
       if (Result.isFailure(employeesWithContracts)) {
@@ -51,12 +54,12 @@ These are the active employees with contracts.
       schema: z.object({
         employeeId: z.string().optional(),
       }),
-    }
+    },
   );
 
 async function fetchActiveEmployeesWithContracts(
   client: GraphQLClientType,
-  companyId: string
+  companyId: string,
 ): Promise<
   Result<GetActiveEmployeesWithContractsQuery["employeesByCompany"], Error>
 > {
@@ -67,7 +70,7 @@ async function fetchActiveEmployeesWithContracts(
           companyId,
           status: [EmployeeAdvancedFilterStatus.Active],
         },
-      }
+      },
     );
     return Result.success(employeesByCompany);
   } catch (e) {

--- a/packages/rita-graphs/src/tools/get-all-employees-drl/tool.ts
+++ b/packages/rita-graphs/src/tools/get-all-employees-drl/tool.ts
@@ -14,7 +14,10 @@ import {
 } from "../../utils/data-representation-layer";
 import { createLogger } from "@the-project-b/logging";
 
-const logger = createLogger({ service: "rita-graphs" }).child({ module: "Tools", tool: "get_all_employees" });
+const logger = createLogger({ service: "rita-graphs" }).child({
+  module: "Tools",
+  tool: "get_all_employees",
+});
 
 /**
  * Since employees is actually "contracts" the employees will contain the same person multiple times if the person has multiple contracts.
@@ -31,7 +34,7 @@ export const getAllEmployees = (
         companyId: ctx.selectedCompanyId,
       });
       const { addItemToDataRepresentationLayer } = ctx.extendedContext;
-      const client = createGraphQLClient(ctx.accessToken);
+      const client = createGraphQLClient(ctx);
 
       const employeesResult = await getAllEmployeeIds(
         client,

--- a/packages/rita-graphs/src/tools/get-current-user/tool.ts
+++ b/packages/rita-graphs/src/tools/get-current-user/tool.ts
@@ -8,7 +8,10 @@ import { Result } from "../../utils/types/result";
 import { GetCurrentUserQuery } from "../../generated/graphql";
 import { createLogger } from "@the-project-b/logging";
 
-const logger = createLogger({ service: "rita-graphs" }).child({ module: "Tools", tool: "get_current_user" });
+const logger = createLogger({ service: "rita-graphs" }).child({
+  module: "Tools",
+  tool: "get_current_user",
+});
 
 export const getCurrentUser = (ctx: ToolContext) =>
   tool(
@@ -17,7 +20,7 @@ export const getCurrentUser = (ctx: ToolContext) =>
         operation: "get_current_user",
         companyId: ctx.selectedCompanyId,
       });
-      const client = createGraphQLClient(ctx.accessToken);
+      const client = createGraphQLClient(ctx);
 
       const currentUser = await fetchCurrentUser(client);
 
@@ -37,11 +40,11 @@ These are the information about the person you are talking to.
     {
       name: "get_current_user",
       description: "Get information about the person you are talking to",
-    }
+    },
   );
 
 async function fetchCurrentUser(
-  client: GraphQLClientType
+  client: GraphQLClientType,
 ): Promise<Result<GetCurrentUserQuery["me"], Error>> {
   try {
     const { me } = await client.getCurrentUser();

--- a/packages/rita-graphs/src/tools/get-employee-by-id/tool.ts
+++ b/packages/rita-graphs/src/tools/get-employee-by-id/tool.ts
@@ -10,7 +10,10 @@ import {
 import { fetchEmployeeById, fetchPaymentsOfEmployee } from "./fetch-helper";
 import { createLogger } from "@the-project-b/logging";
 
-const logger = createLogger({ service: "rita-graphs" }).child({ module: "Tools", tool: "get_employee_by_id" });
+const logger = createLogger({ service: "rita-graphs" }).child({
+  module: "Tools",
+  tool: "get_employee_by_id",
+});
 
 export const getEmployeeById = (ctx: ToolContext) =>
   tool(
@@ -19,12 +22,12 @@ export const getEmployeeById = (ctx: ToolContext) =>
         operation: "get_employee_by_id",
         companyId: ctx.selectedCompanyId,
       });
-      const client = createGraphQLClient(ctx.accessToken);
+      const client = createGraphQLClient(ctx);
 
       const employee = await fetchEmployeeById(
         client,
         ctx.selectedCompanyId,
-        employeeId
+        employeeId,
       );
 
       if (Result.isFailure(employee)) {
@@ -51,7 +54,7 @@ export const getEmployeeById = (ctx: ToolContext) =>
         const paymentsResult = await fetchPaymentsOfEmployee(
           client,
           ctx.selectedCompanyId,
-          employeeInfo.employeeContract
+          employeeInfo.employeeContract,
         );
         if (Result.isFailure(paymentsResult)) {
           return {
@@ -60,7 +63,7 @@ export const getEmployeeById = (ctx: ToolContext) =>
         }
 
         paymentInformation = extractPaymentInformation(
-          Result.unwrap(paymentsResult)
+          Result.unwrap(paymentsResult),
         );
       }
 
@@ -80,5 +83,5 @@ export const getEmployeeById = (ctx: ToolContext) =>
         includePaymentInfo: z.boolean().optional(),
         includeContractInfo: z.boolean().optional(),
       }),
-    }
+    },
   );

--- a/packages/rita-graphs/src/tools/get-payments-of-employee/tool.ts
+++ b/packages/rita-graphs/src/tools/get-payments-of-employee/tool.ts
@@ -22,7 +22,7 @@ export const getPaymentsOfEmployee = (ctx: ToolContext) =>
         employeeId,
         companyId: ctx.selectedCompanyId,
       });
-      const client = createGraphQLClient(ctx.accessToken);
+      const client = createGraphQLClient(ctx);
 
       let employee: GetEmployeeByIdQuery;
       try {

--- a/packages/rita-graphs/src/tools/subgraph-tools/data-change-engine/tools/change-payment-details/tool.ts
+++ b/packages/rita-graphs/src/tools/subgraph-tools/data-change-engine/tools/change-payment-details/tool.ts
@@ -1,10 +1,7 @@
 import { tool } from "@langchain/core/tools";
 import { z } from "zod";
 import { createGraphQLClient } from "../../../../../utils/graphql/client";
-import {
-  ToolContext,
-  ToolFactoryToolDefintion,
-} from "../../../../tool-factory";
+import { ToolFactoryToolDefintion } from "../../../../tool-factory";
 import { DataChangeProposal } from "../../../../../graphs/shared-types/base-annotation";
 import { randomUUID as uuid } from "crypto";
 import {
@@ -29,9 +26,7 @@ function prefixedLog(message: string, data?: any) {
   logger.debug(message, data);
 }
 
-export const changePaymentDetails: ToolFactoryToolDefintion<ToolContext> = (
-  ctx,
-) =>
+export const changePaymentDetails: ToolFactoryToolDefintion = (ctx) =>
   tool(
     async (params, config) => {
       const {
@@ -54,7 +49,7 @@ export const changePaymentDetails: ToolFactoryToolDefintion<ToolContext> = (
         companyId: selectedCompanyId,
       });
 
-      const client = createGraphQLClient(accessToken);
+      const client = createGraphQLClient(ctx);
 
       // 1) Get how many contracts the employee has
 
@@ -186,7 +181,12 @@ export const changePaymentDetails: ToolFactoryToolDefintion<ToolContext> = (
 
       const newProposalDbUpdateResults = await Promise.all(
         newProposals.map((proposal) =>
-          createThreadItemForProposal(proposal, thread_id, accessToken),
+          createThreadItemForProposal(
+            proposal,
+            thread_id,
+            accessToken,
+            ctx.appdataHeader,
+          ),
         ),
       );
 
@@ -199,14 +199,17 @@ export const changePaymentDetails: ToolFactoryToolDefintion<ToolContext> = (
           .map((item) => Result.unwrapFailure(item))
           .join("\n");
 
-        logger.error("Failed to create thread items for the data change proposals", {
-          threadId: thread_id,
-          issues,
-          employeeId,
-          paymentId,
-          contractId,
-          companyId: selectedCompanyId,
-        });
+        logger.error(
+          "Failed to create thread items for the data change proposals",
+          {
+            threadId: thread_id,
+            issues,
+            employeeId,
+            paymentId,
+            contractId,
+            companyId: selectedCompanyId,
+          },
+        );
 
         return {
           error: "Failed to create thread items for the data change proposals.",
@@ -247,9 +250,10 @@ async function createThreadItemForProposal(
   proposal: DataChangeProposal,
   threadId: string,
   accessToken: string,
+  appdataHeader?: string,
 ): Promise<Result<CreateRitaThreadItemMutation>> {
   try {
-    const client = createGraphQLClient(accessToken);
+    const client = createGraphQLClient({ accessToken, appdataHeader });
     const threadItem = await client.createRitaThreadItem({
       input: {
         ritaThreadId: threadId,

--- a/packages/rita-graphs/src/tools/subgraph-tools/data-change-engine/tools/find-employee-by-name-with-contract/tool.ts
+++ b/packages/rita-graphs/src/tools/subgraph-tools/data-change-engine/tools/find-employee-by-name-with-contract/tool.ts
@@ -9,7 +9,10 @@ import { Result } from "../../../../../utils/types/result";
 import { FindEmployeeByNameWithContractQuery } from "../../../../../generated/graphql";
 import { createLogger } from "@the-project-b/logging";
 
-const logger = createLogger({ service: "rita-graphs" }).child({ module: "Tools", tool: "find_employee_by_name_with_contract" });
+const logger = createLogger({ service: "rita-graphs" }).child({
+  module: "Tools",
+  tool: "find_employee_by_name_with_contract",
+});
 
 export const findEmployeeByNameWithContract = (ctx: ToolContext) =>
   tool(
@@ -18,7 +21,7 @@ export const findEmployeeByNameWithContract = (ctx: ToolContext) =>
         operation: "find_employee_by_name_with_contract",
         companyId: ctx.selectedCompanyId,
       });
-      const client = createGraphQLClient(ctx.accessToken);
+      const client = createGraphQLClient(ctx);
 
       const employees = await Promise.all(
         nameParts.map((namePart) =>

--- a/packages/rita-graphs/src/tools/subgraph-tools/data-change-engine/tools/get-current_data_change_proposals/tool.ts
+++ b/packages/rita-graphs/src/tools/subgraph-tools/data-change-engine/tools/get-current_data_change_proposals/tool.ts
@@ -15,13 +15,11 @@ const logger = createLogger({ service: "rita-graphs" }).child({
   tool: "get_current_data_change_proposals",
 });
 
-export const getCurrentDataChangeProposals: ToolFactoryToolDefintion<
-  ToolContext
-> = (ctx) =>
+export const getCurrentDataChangeProposals: ToolFactoryToolDefintion = (ctx) =>
   tool(
     async (_, { configurable }) => {
       const { thread_id } = configurable;
-      const { accessToken } = ctx;
+      // const { accessToken } = ctx;
 
       logger.info("[TOOL > get_current_data_change_proposals]", {
         operation: "get_current_data_change_proposals",
@@ -30,7 +28,7 @@ export const getCurrentDataChangeProposals: ToolFactoryToolDefintion<
 
       const threadItemsResult = await getThreadItemsByLanggraphThreadId(
         thread_id,
-        accessToken,
+        ctx,
       );
 
       if (Result.isFailure(threadItemsResult)) {
@@ -66,14 +64,14 @@ These are the pending data change proposals. You can use them to approve the bas
 
 async function getThreadItemsByLanggraphThreadId(
   threadId: string,
-  accessToken: string,
+  ctx: ToolContext,
 ): Promise<
   Result<
     GetThreadItemsByLanggraphThreadIdQuery["threadByLanggraphId"]["threadItems"]
   >
 > {
   try {
-    const client = createGraphQLClient(accessToken);
+    const client = createGraphQLClient(ctx);
     const threadItems = await client.getThreadItemsByLanggraphThreadId({
       langgraphId: threadId,
     });

--- a/packages/rita-graphs/src/tools/tool-factory.ts
+++ b/packages/rita-graphs/src/tools/tool-factory.ts
@@ -1,11 +1,15 @@
 import { ToolInterface } from "@langchain/core/tools";
 import { createLogger } from "@the-project-b/logging";
 
-const logger = createLogger({ service: "rita-graphs" }).child({ module: "Tools", tool: "tool_factory" });
+const logger = createLogger({ service: "rita-graphs" }).child({
+  module: "Tools",
+  tool: "tool_factory",
+});
 
 export type ToolContext<T = undefined> = {
   accessToken: string;
   selectedCompanyId: string;
+  appdataHeader?: string; // Optional appdata header for impersonation context
   extendedContext?: T;
 };
 

--- a/packages/rita-graphs/src/utils/graphql/client.ts
+++ b/packages/rita-graphs/src/utils/graphql/client.ts
@@ -1,14 +1,52 @@
 import { GraphQLClient } from "graphql-request";
 import { getSdk, Sdk } from "../../generated/graphql";
+import { ToolContext } from "../../tools/tool-factory";
 
-export function createGraphQLClient(accessToken: string): Sdk {
+type GraphQLClientOverrides = {
+  accessToken?: string;
+  appdataHeader?: string;
+};
+
+/**
+ * Creates a GraphQL client with authentication and optional impersonation context
+ *
+ * @param ctx - Tool context containing accessToken and optional appdataHeader, or a plain object with these properties
+ * @param overrides - Optional overrides for accessToken or appdataHeader
+ * @returns GraphQL SDK client configured with proper authentication headers
+ *
+ * @example
+ * // Normal usage with tool context
+ * const client = createGraphQLClient(ctx);
+ *
+ * @example
+ * // Usage with overrides when you need to pass different credentials
+ * const client = createGraphQLClient(ctx, {
+ *   accessToken: 'different-token',
+ *   appdataHeader: 'custom-appdata'
+ * });
+ */
+export function createGraphQLClient(
+  ctx: ToolContext | { accessToken: string; appdataHeader?: string },
+  overrides?: GraphQLClientOverrides,
+): Sdk {
+  // Extract values from context, with overrides taking precedence
+  const accessToken = overrides?.accessToken ?? ctx.accessToken;
+  const appdataHeader = overrides?.appdataHeader ?? ctx.appdataHeader;
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${accessToken}`,
+  };
+
+  // Pass the appdata header if available for impersonation context when we hit our backend, we pass the original value that was sent to us through the passthrough layer
+  if (appdataHeader) {
+    headers["X-Appdata"] = appdataHeader;
+  }
+
   const client = new GraphQLClient(
     `${process.env.PROJECTB_GRAPHQL_ENDPOINT}/schema`,
     {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    }
+      headers,
+    },
   );
   const sdk = getSdk(client);
 


### PR DESCRIPTION
- Also updated the function 'createGraphQLClient' on the rita-graph package to accept the full context and extract what we need, allowing for less code changes needed in the future if we extend auth-related headers or context
- Cleaned up the experiments service a bit, which, just like before, doesn't support impersonation during runs yet, not sure if we'll have a need for this (although might be useful to run impersonation-related examples too)