### PR TITLE
feat: Prompt engineering - Langsmith adapter, prompt service and first integration in graph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19589,7 +19589,10 @@
       "name": "@the-project-b/prompts",
       "version": "0.0.1",
       "dependencies": {
-        "@the-project-b/logging": "*"
+        "@langchain/core": "0.3.72",
+        "@the-project-b/logging": "*",
+        "langchain": "^0.3.33",
+        "langsmith": "^0.3.63"
       },
       "devDependencies": {
         "@tsconfig/recommended": "^1.0.10",
@@ -19597,6 +19600,114 @@
         "jest": "^29.7.0",
         "ts-jest": "^29.3.4",
         "typescript": "^5.8.3"
+      }
+    },
+    "packages/prompts/node_modules/langchain": {
+      "version": "0.3.33",
+      "resolved": "https://registry.npmjs.org/langchain/-/langchain-0.3.33.tgz",
+      "integrity": "sha512-MgMfy/68/xUi02dSg4AZhXjo4jQ+WuVYrU/ryzn59nUb+LXaMRoP/C9eaqblin0OLqGp93jfT8FXDg5mcqSg5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/openai": ">=0.1.0 <0.7.0",
+        "@langchain/textsplitters": ">=0.0.0 <0.2.0",
+        "js-tiktoken": "^1.0.12",
+        "js-yaml": "^4.1.0",
+        "jsonpointer": "^5.0.1",
+        "langsmith": "^0.3.46",
+        "openapi-types": "^12.1.3",
+        "p-retry": "4",
+        "uuid": "^10.0.0",
+        "yaml": "^2.2.1",
+        "zod": "^3.25.32"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/anthropic": "*",
+        "@langchain/aws": "*",
+        "@langchain/cerebras": "*",
+        "@langchain/cohere": "*",
+        "@langchain/core": ">=0.3.58 <0.4.0",
+        "@langchain/deepseek": "*",
+        "@langchain/google-genai": "*",
+        "@langchain/google-vertexai": "*",
+        "@langchain/google-vertexai-web": "*",
+        "@langchain/groq": "*",
+        "@langchain/mistralai": "*",
+        "@langchain/ollama": "*",
+        "@langchain/xai": "*",
+        "axios": "*",
+        "cheerio": "*",
+        "handlebars": "^4.7.8",
+        "peggy": "^3.0.2",
+        "typeorm": "*"
+      },
+      "peerDependenciesMeta": {
+        "@langchain/anthropic": {
+          "optional": true
+        },
+        "@langchain/aws": {
+          "optional": true
+        },
+        "@langchain/cerebras": {
+          "optional": true
+        },
+        "@langchain/cohere": {
+          "optional": true
+        },
+        "@langchain/deepseek": {
+          "optional": true
+        },
+        "@langchain/google-genai": {
+          "optional": true
+        },
+        "@langchain/google-vertexai": {
+          "optional": true
+        },
+        "@langchain/google-vertexai-web": {
+          "optional": true
+        },
+        "@langchain/groq": {
+          "optional": true
+        },
+        "@langchain/mistralai": {
+          "optional": true
+        },
+        "@langchain/ollama": {
+          "optional": true
+        },
+        "@langchain/xai": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "cheerio": {
+          "optional": true
+        },
+        "handlebars": {
+          "optional": true
+        },
+        "peggy": {
+          "optional": true
+        },
+        "typeorm": {
+          "optional": true
+        }
+      }
+    },
+    "packages/prompts/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "packages/rita-graphs": {

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -19,6 +19,9 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@the-project-b/logging": "*"
+    "@langchain/core": "0.3.72",
+    "@the-project-b/logging": "*",
+    "langchain": "^0.3.33",
+    "langsmith": "^0.3.63"
   }
 }

--- a/packages/prompts/src/application/dto/format-prompt.dto.ts
+++ b/packages/prompts/src/application/dto/format-prompt.dto.ts
@@ -30,6 +30,7 @@ export interface FormattedPromptResponse {
       truncatedTo: number;
     }>;
     correlationId?: string;
+    source?: string;
   };
 }
 

--- a/packages/prompts/src/application/services/prompt.service.ts
+++ b/packages/prompts/src/application/services/prompt.service.ts
@@ -1,0 +1,289 @@
+import { Result } from "../../shared/types/result.js";
+import {
+  NotFoundError,
+  PersistenceError,
+  FormatError,
+} from "../../shared/errors/domain.errors.js";
+import { PromptRepository } from "../../domain/repositories/prompt.repository.js";
+import { Prompt } from "../../domain/entities/prompt.entity.js";
+import { PromptId } from "../../domain/value-objects/prompt-id.value-object.js";
+import { LanguageCode } from "../../domain/value-objects/language-code.value-object.js";
+import { PromptCategory } from "../../domain/value-objects/prompt-metadata.value-object.js";
+import { PromptVariables } from "../../domain/value-objects/prompt-variables.value-object.js";
+import { CreateChatPromptUseCase } from "../use-cases/create-chat-prompt.use-case.js";
+import type { FormattedPromptResponse } from "../dto/format-prompt.dto.js";
+import type {
+  CreateChatPromptParams,
+  ChatPromptResponse,
+} from "../dto/chat-prompt.dto.js";
+import type { Logger } from "@the-project-b/logging";
+
+/**
+ * Available repository sources for prompts.
+ */
+export type PromptSource = "memory" | "langsmith" | string;
+
+/**
+ * Configuration for the PromptService.
+ */
+export interface PromptServiceConfig {
+  repositories: Record<PromptSource, PromptRepository>;
+  defaultSource?: PromptSource;
+  logger?: Logger;
+}
+
+/**
+ * Parameters for formatting a prompt.
+ */
+export interface FormatPromptParams {
+  promptName: string;
+  source?: PromptSource;
+  variables?: Record<string, unknown>;
+  language?: string;
+  maxLength?: number;
+  correlationId?: string;
+}
+
+/**
+ * Parameters for registering a prompt.
+ */
+export interface RegisterPromptParams {
+  id?: string;
+  name: string;
+  templates: Map<string, string> | { [key: string]: string };
+  category?: PromptCategory;
+  variables?: PromptVariables;
+  metadata?: {
+    version?: string;
+    tags?: string[];
+    owner?: string;
+    description?: string;
+  };
+  source?: PromptSource;
+}
+
+/**
+ * Service for managing prompts across multiple repositories.
+ * Provides a unified interface for prompt operations with source selection.
+ */
+export class PromptService {
+  private readonly repositories: Map<PromptSource, PromptRepository>;
+  private readonly defaultSource: PromptSource;
+  private readonly createChatPromptUseCase: CreateChatPromptUseCase;
+  private readonly logger?: Logger;
+
+  constructor(config: PromptServiceConfig) {
+    this.repositories = new Map(Object.entries(config.repositories));
+    this.defaultSource = config.defaultSource || "memory";
+    this.logger = config.logger;
+
+    if (!this.repositories.has(this.defaultSource)) {
+      throw new Error(
+        `Default source '${this.defaultSource}' not found in repositories`,
+      );
+    }
+
+    // Initialize use case with the default repository
+    const defaultRepo = this.repositories.get(this.defaultSource)!;
+    this.createChatPromptUseCase = new CreateChatPromptUseCase(
+      defaultRepo,
+      config.logger,
+    );
+
+    config.logger?.info("PromptService initialized", {
+      sources: Array.from(this.repositories.keys()),
+      defaultSource: this.defaultSource,
+    });
+  }
+
+  /**
+   * Gets a repository by source name.
+   * @param source - The source to get
+   * @returns Result<PromptRepository, NotFoundError>
+   */
+  private getRepository(
+    source?: PromptSource,
+  ): Result<PromptRepository, NotFoundError> {
+    const targetSource = source || this.defaultSource;
+    const repository = this.repositories.get(targetSource);
+
+    if (!repository) {
+      return Result.failure(new NotFoundError("Repository", targetSource));
+    }
+
+    return Result.success(repository);
+  }
+
+  /**
+   * Formats a prompt with variables from the specified source.
+   * @param params - Formatting parameters
+   * @returns Promise<Result<FormattedPromptResponse, FormatError | NotFoundError>>
+   */
+  async formatPrompt(
+    params: FormatPromptParams,
+  ): Promise<Result<FormattedPromptResponse, FormatError | NotFoundError>> {
+    this.logger?.debug("Formatting prompt", {
+      promptName: params.promptName,
+      source: params.source || this.defaultSource,
+    });
+
+    const repoResult = this.getRepository(params.source);
+    if (Result.isFailure(repoResult)) {
+      return Result.failure(Result.unwrapFailure(repoResult));
+    }
+
+    const repository = Result.unwrap(repoResult);
+
+    // Find the prompt by name
+    const promptResult = await repository.findByName(params.promptName);
+    if (Result.isFailure(promptResult)) {
+      return Result.failure(Result.unwrapFailure(promptResult));
+    }
+
+    const prompt = Result.unwrap(promptResult);
+
+    // Format the prompt with variables
+    const language = params.language
+      ? LanguageCode.fromString(params.language)
+      : Result.success(LanguageCode.getDefault());
+
+    if (Result.isFailure(language)) {
+      return Result.failure(
+        new FormatError(`Invalid language: ${params.language}`),
+      );
+    }
+
+    const formatResult = params.maxLength
+      ? prompt.formatWithTruncation(
+          params.variables || {},
+          Result.unwrap(language),
+          params.maxLength,
+        )
+      : prompt.format(params.variables || {}, Result.unwrap(language));
+
+    if (Result.isFailure(formatResult)) {
+      return Result.failure(Result.unwrapFailure(formatResult));
+    }
+
+    const formatted = Result.unwrap(formatResult);
+
+    // Create extended response with additional metadata
+    const response: FormattedPromptResponse = {
+      ...formatted,
+      metadata: {
+        ...formatted.metadata,
+        correlationId: params.correlationId,
+        source: params.source || this.defaultSource,
+      },
+    };
+
+    return Result.success(response);
+  }
+
+  /**
+   * Creates a chat prompt from messages.
+   * @param params - Chat prompt parameters
+   * @returns Promise<Result<ChatPromptResponse, FormatError>>
+   */
+  async createChatPrompt(
+    params: CreateChatPromptParams,
+  ): Promise<Result<ChatPromptResponse, FormatError>> {
+    return this.createChatPromptUseCase.execute(params);
+  }
+
+  /**
+   * Registers a new prompt in the specified repository.
+   * @param params - Registration parameters
+   * @returns Promise<Result<void, PersistenceError | NotFoundError>>
+   */
+  async registerPrompt(
+    params: RegisterPromptParams,
+  ): Promise<Result<void, PersistenceError | NotFoundError>> {
+    const repoResult = this.getRepository(params.source);
+    if (Result.isFailure(repoResult)) {
+      return Result.failure(Result.unwrapFailure(repoResult));
+    }
+
+    const repository = Result.unwrap(repoResult);
+
+    // Create the prompt entity
+    const promptResult = Prompt.create({
+      id: params.id || `${params.name}-${Date.now()}`,
+      name: params.name,
+      category: params.category,
+      templates: params.templates,
+      variables: params.variables,
+      metadata: params.metadata,
+    });
+
+    if (Result.isFailure(promptResult)) {
+      return Result.failure(
+        new PersistenceError(
+          `Failed to create prompt: ${Result.unwrapFailure(promptResult).message}`,
+        ),
+      );
+    }
+
+    const prompt = Result.unwrap(promptResult);
+    return repository.save(prompt);
+  }
+
+  /**
+   * Gets a prompt by ID from the specified source.
+   * @param id - The prompt ID
+   * @param source - The source to query
+   * @returns Promise<Result<Prompt, NotFoundError>>
+   */
+  async getPrompt(
+    id: string,
+    source?: PromptSource,
+  ): Promise<Result<Prompt, NotFoundError>> {
+    const repoResult = this.getRepository(source);
+    if (Result.isFailure(repoResult)) {
+      return Result.failure(Result.unwrapFailure(repoResult));
+    }
+
+    const repository = Result.unwrap(repoResult);
+    const promptIdResult = PromptId.create(id);
+    if (Result.isFailure(promptIdResult)) {
+      return Result.failure(new NotFoundError("Prompt", id));
+    }
+
+    return repository.findById(Result.unwrap(promptIdResult));
+  }
+
+  /**
+   * Gets a prompt by name from the specified source.
+   * @param name - The prompt name
+   * @param source - The source to query
+   * @returns Promise<Result<Prompt, NotFoundError>>
+   */
+  async getPromptByName(
+    name: string,
+    source?: PromptSource,
+  ): Promise<Result<Prompt, NotFoundError>> {
+    const repoResult = this.getRepository(source);
+    if (Result.isFailure(repoResult)) {
+      return Result.failure(Result.unwrapFailure(repoResult));
+    }
+
+    const repository = Result.unwrap(repoResult);
+    return repository.findByName(name);
+  }
+
+  /**
+   * Lists all available sources.
+   * @returns string[] - Array of source names
+   */
+  listSources(): string[] {
+    return Array.from(this.repositories.keys());
+  }
+
+  /**
+   * Gets the default source.
+   * @returns string - The default source name
+   */
+  getDefaultSource(): string {
+    return this.defaultSource;
+  }
+}

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -7,15 +7,15 @@ export type {
 } from "./domain/entities/prompt.entity.js";
 
 // Value Objects
-export { PromptId } from "./domain/value-objects/prompt-id.value-object.js";
-export { PromptTemplate } from "./domain/value-objects/prompt-template.value-object.js";
 export { LanguageCode } from "./domain/value-objects/language-code.value-object.js";
+export { PromptId } from "./domain/value-objects/prompt-id.value-object.js";
+export {
+  PromptCategory,
+  PromptMetadata,
+} from "./domain/value-objects/prompt-metadata.value-object.js";
+export { PromptTemplate } from "./domain/value-objects/prompt-template.value-object.js";
 export { PromptVariables } from "./domain/value-objects/prompt-variables.value-object.js";
 export type { VariableDefinition } from "./domain/value-objects/prompt-variables.value-object.js";
-export {
-  PromptMetadata,
-  PromptCategory,
-} from "./domain/value-objects/prompt-metadata.value-object.js";
 
 // Services
 export { PromptFormatterService } from "./domain/services/prompt-formatter.service.js";
@@ -23,69 +23,87 @@ export type { FormattingResult } from "./domain/services/prompt-formatter.servic
 
 // Repositories
 export type {
-  PromptRepository,
   PromptFilter,
+  PromptRepository,
 } from "./domain/repositories/prompt.repository.js";
 // #endregion
 
 // #region Application Exports
 // Use Cases
-export { FormatSimplePromptUseCase } from "./application/use-cases/format-simple-prompt.use-case.js";
 export { CreateChatPromptUseCase } from "./application/use-cases/create-chat-prompt.use-case.js";
+export { FormatSimplePromptUseCase } from "./application/use-cases/format-simple-prompt.use-case.js";
 
 // DTOs
-export type {
-  FormatSimplePromptParams,
-  FormattedPromptResponse,
-  FormatWithTruncationParams,
-} from "./application/dto/format-prompt.dto.js";
 export type {
   ChatMessage,
   ChatPromptConfig,
   ChatPromptResponse,
   CreateChatPromptParams,
+  FormatChatMessagesParams,
   MessageRole,
   MessageSpec,
-  FormatChatMessagesParams,
 } from "./application/dto/chat-prompt.dto.js";
+export type {
+  FormatSimplePromptParams,
+  FormattedPromptResponse,
+  FormatWithTruncationParams,
+} from "./application/dto/format-prompt.dto.js";
 
 // Services
 export { PromptRegistryService } from "./application/services/prompt-registry.service.js";
+export { PromptService } from "./application/services/prompt.service.js";
+export type {
+  FormatPromptParams,
+  PromptServiceConfig,
+  PromptSource,
+  RegisterPromptParams,
+} from "./application/services/prompt.service.js";
 // #endregion
 
 // #region Infrastructure Exports
 // Adapters
-export { LangChainPromptAdapter } from "./infrastructure/adapters/langchain-prompt.adapter.js";
-export type { LangChainCompatiblePrompt } from "./infrastructure/adapters/langchain-prompt.adapter.js";
 export { LangChainChatAdapter } from "./infrastructure/adapters/langchain-chat.adapter.js";
 export type {
   LangChainCompatibleChatPrompt,
   LangChainMessage,
 } from "./infrastructure/adapters/langchain-chat.adapter.js";
+export { LangChainPromptAdapter } from "./infrastructure/adapters/langchain-prompt.adapter.js";
+export type { LangChainCompatiblePrompt } from "./infrastructure/adapters/langchain-prompt.adapter.js";
 
 // Factories
 export {
-  MessageFactory,
   MessageBuilder,
+  MessageFactory,
 } from "./infrastructure/factories/message.factory.js";
 
 // Repositories
 export { InMemoryPromptRepository } from "./infrastructure/repositories/in-memory-prompt.repository.js";
+export { LangSmithPromptRepository } from "./infrastructure/repositories/langsmith-prompt.repository.js";
+
+// Clients
+export { LangSmithClientAdapter } from "./infrastructure/clients/langsmith-client.adapter.js";
+export type {
+  LangSmithClient,
+  LangSmithConfig,
+  LangSmithMessage,
+  LangSmithPrompt,
+  LangSmithPullOptions,
+} from "./infrastructure/clients/langsmith-client.types.js";
 // #endregion
 
 // #region Shared Exports
 // Result Pattern
 export { Result } from "./shared/types/result.js";
-export type { Success, Failure } from "./shared/types/result.js";
+export type { Failure, Success } from "./shared/types/result.js";
 
 // Errors
 export {
   DomainError,
-  ValidationError,
+  FormatError,
+  LanguageNotSupportedError,
   NotFoundError,
   PersistenceError,
-  FormatError,
   PromptCreationError,
-  LanguageNotSupportedError,
+  ValidationError,
 } from "./shared/errors/domain.errors.js";
 // #endregion

--- a/packages/prompts/src/infrastructure/clients/langsmith-client.adapter.ts
+++ b/packages/prompts/src/infrastructure/clients/langsmith-client.adapter.ts
@@ -1,0 +1,282 @@
+import { Client } from "langsmith";
+import * as hub from "langchain/hub/node";
+import type { 
+  BasePromptTemplate,
+  ChatPromptTemplate,
+  PromptTemplate 
+} from "@langchain/core/prompts";
+import type { BaseMessage } from "@langchain/core/messages";
+import { Result } from "../../shared/types/result.js";
+import { PersistenceError } from "../../shared/errors/domain.errors.js";
+import type {
+  LangSmithClient,
+  LangSmithPrompt,
+  LangSmithPullOptions,
+  LangSmithConfig,
+  LangSmithMessage,
+} from "./langsmith-client.types.js";
+import type { Logger } from "@the-project-b/logging";
+
+/**
+ * Adapter for the actual LangSmith SDK Client.
+ * Uses @langchain/core hub for pulling prompts from LangSmith.
+ */
+export class LangSmithClientAdapter implements LangSmithClient {
+  private client: Client;
+
+  constructor(
+    config: LangSmithConfig,
+    private readonly logger?: Logger,
+  ) {
+    // Initialize the LangSmith client for other operations
+    this.client = new Client({
+      apiKey: config.apiKey,
+      apiUrl: config.apiUrl,
+    });
+
+    // Set environment variables for hub.pull to work
+    if (config.apiKey) {
+      process.env.LANGSMITH_API_KEY = config.apiKey;
+    }
+    // Set the endpoint - for EU users it should be https://eu.api.smith.langchain.com
+    if (config.apiUrl) {
+      process.env.LANGSMITH_ENDPOINT = config.apiUrl;
+    } else if (!process.env.LANGSMITH_ENDPOINT) {
+      // Default to US endpoint if not specified
+      process.env.LANGSMITH_ENDPOINT = "https://api.smith.langchain.com";
+    }
+
+    this.logger?.info("LangSmith client initialized", {
+      apiUrl: config.apiUrl || "https://api.smith.langchain.com",
+      workspace: config.workspace,
+    });
+  }
+
+  /**
+   * Pulls a prompt from LangSmith by name using the hub module.
+   * @param promptName - The name of the prompt (e.g., "my-prompt" or "owner/my-prompt")
+   * @param options - Optional pull parameters
+   * @returns Promise<Result<LangSmithPrompt, PersistenceError>>
+   */
+  async pullPrompt(
+    promptName: string,
+    options?: LangSmithPullOptions,
+  ): Promise<Result<LangSmithPrompt, PersistenceError>> {
+    try {
+      this.logger?.debug("Pulling prompt from LangSmith", {
+        promptName,
+        options,
+      });
+
+      // Use the hub.pull method from langchain/hub
+      const prompt = await hub.pull<BasePromptTemplate>(promptName, options);
+      
+      this.logger?.info("Successfully pulled prompt from LangSmith hub", {
+        promptName,
+        promptType: prompt.constructor.name,
+        inputVariables: prompt.inputVariables,
+        hasPromptMessages: "promptMessages" in prompt,
+        hasTemplate: "template" in prompt,
+      });
+
+      // Transform the LangChain prompt to our internal format
+      const transformedPrompt = this.transformLangChainPrompt(
+        prompt,
+        promptName,
+      );
+      
+      this.logger?.info("Transformed LangChain prompt to LangSmith format", {
+        transformedPrompt,
+      });
+
+      return Result.success(transformedPrompt);
+    } catch (error) {
+      this.logger?.error("Failed to pull prompt from LangSmith", {
+        promptName,
+        error: error instanceof Error ? error.message : error,
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : "Unknown error occurred while pulling prompt";
+
+      return Result.failure(
+        new PersistenceError(`Failed to pull prompt: ${errorMessage}`),
+      );
+    }
+  }
+
+  /**
+   * Type guard to check if a prompt is a ChatPromptTemplate
+   */
+  private isChatPromptTemplate(
+    prompt: BasePromptTemplate
+  ): prompt is ChatPromptTemplate {
+    return "promptMessages" in prompt && Array.isArray((prompt as ChatPromptTemplate).promptMessages);
+  }
+
+  /**
+   * Type guard to check if a prompt is a simple PromptTemplate
+   */
+  private isPromptTemplate(
+    prompt: BasePromptTemplate
+  ): prompt is PromptTemplate {
+    return "template" in prompt && typeof (prompt as PromptTemplate).template === "string";
+  }
+
+  /**
+   * Transform a LangChain prompt template to our internal format.
+   * @param prompt - The prompt from LangChain hub
+   * @param promptName - The name of the prompt
+   * @returns LangSmithPrompt
+   */
+  private transformLangChainPrompt(
+    prompt: BasePromptTemplate,
+    promptName: string,
+  ): LangSmithPrompt {
+    // Extract template content based on prompt type
+    let template: string | LangSmithMessage[];
+    let inputVariables: string[] = [];
+
+    // Check if it's a ChatPromptTemplate
+    if (this.isChatPromptTemplate(prompt)) {
+      const chatPrompt = prompt as ChatPromptTemplate;
+      
+      // For now, we'll extract the first message template
+      // In a chat prompt, we typically have a system message
+      if (chatPrompt.promptMessages.length > 0) {
+        const firstMessage = chatPrompt.promptMessages[0];
+        
+        this.logger?.info("Examining first prompt message", {
+          hasPrompt: "prompt" in firstMessage,
+          hasContent: "content" in firstMessage,
+          hasTemplate: "template" in firstMessage,
+          constructorName: firstMessage.constructor.name,
+          keys: Object.keys(firstMessage),
+        });
+        
+        // Check if it's a message prompt template with a prompt property
+        if ("prompt" in firstMessage && typeof firstMessage.prompt === "object") {
+          const messageTemplate = firstMessage as any; // Using any temporarily to access prompt
+          this.logger?.info("Found prompt property in message", {
+            promptKeys: Object.keys(messageTemplate.prompt),
+            hasTemplate: "template" in messageTemplate.prompt,
+            templateType: typeof messageTemplate.prompt.template,
+          });
+          
+          if ("template" in messageTemplate.prompt) {
+            // This is a string template
+            template = messageTemplate.prompt.template;
+          } else {
+            template = "";
+          }
+        } else if ("content" in firstMessage && typeof firstMessage === "object") {
+          // This is a BaseMessage with direct content
+          const baseMsg = firstMessage as BaseMessage;
+          template = typeof baseMsg.content === "string" 
+            ? baseMsg.content 
+            : JSON.stringify(baseMsg.content);
+        } else {
+          // Fallback: try to get any template string
+          template = "";
+        }
+      } else {
+        template = "";
+      }
+    } else if (this.isPromptTemplate(prompt)) {
+      // Simple PromptTemplate
+      const simplePrompt = prompt as PromptTemplate;
+      template = typeof simplePrompt.template === "string" 
+        ? simplePrompt.template 
+        : JSON.stringify(simplePrompt.template);
+    } else {
+      // Fallback for unknown prompt types
+      this.logger?.warn("Unknown prompt type, using empty template", {
+        promptName,
+        promptType: prompt.constructor.name,
+      });
+      template = "";
+    }
+
+    // Extract input variables - this is on the base class
+    if (prompt.inputVariables && Array.isArray(prompt.inputVariables)) {
+      inputVariables = prompt.inputVariables as string[];
+    }
+
+    // Generate a unique ID based on the prompt name
+    const id = `langsmith-${promptName.replace(/\//g, "-")}`;
+
+    return {
+      id,
+      name: promptName,
+      description: `Prompt pulled from LangSmith: ${promptName}`,
+      object: "prompt",
+      template,
+      input_variables: inputVariables,
+      metadata: {
+        tags: [],
+        version: "1.0.0",
+        source: "langsmith",
+      },
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Lists all prompts - currently not supported.
+   * The hub module doesn't provide a list operation.
+   * @param limit - Maximum number of prompts
+   * @param offset - Pagination offset
+   * @returns Promise<Result<LangSmithPrompt[], PersistenceError>>
+   */
+  async listPrompts(
+    limit?: number,
+    offset?: number,
+  ): Promise<Result<LangSmithPrompt[], PersistenceError>> {
+    this.logger?.debug("Listing prompts from LangSmith", {
+      limit,
+      offset,
+    });
+
+    // The hub module doesn't support listing prompts
+    // This would require direct API access or a different approach
+    return Result.failure(
+      new PersistenceError(
+        "Listing prompts is not supported through the hub module. Prompts must be pulled by name.",
+      ),
+    );
+  }
+
+  /**
+   * Lists all versions of a specific prompt - currently not supported.
+   * @param promptName - The name of the prompt
+   * @returns Promise<Result<LangSmithPrompt[], PersistenceError>>
+   */
+  async listPromptVersions(
+    promptName: string,
+  ): Promise<Result<LangSmithPrompt[], PersistenceError>> {
+    this.logger?.debug("Listing prompt versions from LangSmith", {
+      promptName,
+    });
+
+    // Version listing would require direct API access
+    // The hub module pulls specific versions but doesn't list them
+    return Result.failure(
+      new PersistenceError(
+        "Listing prompt versions is not directly supported. Use specific version tags when pulling prompts.",
+      ),
+    );
+  }
+
+  /**
+   * Gets the underlying LangSmith client for advanced operations.
+   * Use with caution - prefer the typed methods when possible.
+   * @returns Client - The LangSmith client instance
+   */
+  getClient(): Client {
+    return this.client;
+  }
+}

--- a/packages/prompts/src/infrastructure/clients/langsmith-client.types.ts
+++ b/packages/prompts/src/infrastructure/clients/langsmith-client.types.ts
@@ -1,0 +1,99 @@
+import { Result } from "../../shared/types/result.js";
+import { PersistenceError } from "../../shared/errors/domain.errors.js";
+
+/**
+ * Represents a message in a chat prompt.
+ */
+export interface LangSmithMessage {
+  role: "system" | "human" | "assistant" | "user" | string;
+  content: string;
+}
+
+/**
+ * LangSmith prompt representation based on the actual SDK.
+ * Represents the structure returned by the LangSmith API.
+ */
+export interface LangSmithPrompt {
+  id: string;
+  name: string;
+  description?: string;
+  object: string; // Usually "prompt"
+  // The template can be a string for simple prompts or an array for chat prompts
+  template: string | LangSmithMessage[];
+  input_variables?: string[];
+  // Metadata about the prompt
+  metadata?: {
+    tags?: string[];
+    version?: string;
+    [key: string]: unknown;
+  };
+  created_at?: string;
+  updated_at?: string;
+  // Optional model configuration
+  model?: {
+    model_name?: string;
+    temperature?: number;
+    max_tokens?: number;
+    [key: string]: unknown;
+  };
+}
+
+/**
+ * Options for pulling prompts from LangSmith.
+ * Based on the actual SDK parameters.
+ */
+export interface LangSmithPullOptions {
+  // Specific commit hash or tag
+  version?: string;
+  // Include model configuration in the response
+  includeModel?: boolean;
+}
+
+/**
+ * LangSmith client interface.
+ * Abstracts the LangSmith SDK for testing and flexibility.
+ */
+export interface LangSmithClient {
+  /**
+   * Pulls a prompt from LangSmith by name.
+   * Mirrors the SDK's pullPrompt functionality.
+   * @param promptName - The name of the prompt in LangSmith (e.g., "my-prompt" or "owner/my-prompt")
+   * @param options - Optional pull parameters
+   * @returns Promise<Result<LangSmithPrompt, PersistenceError>>
+   */
+  pullPrompt(
+    promptName: string,
+    options?: LangSmithPullOptions,
+  ): Promise<Result<LangSmithPrompt, PersistenceError>>;
+
+  /**
+   * Lists all prompts in LangSmith (if supported).
+   * Note: This might not be available in all SDK versions.
+   * @param limit - Maximum number of prompts to return
+   * @param offset - Offset for pagination
+   * @returns Promise<Result<LangSmithPrompt[], PersistenceError>>
+   */
+  listPrompts?(
+    limit?: number,
+    offset?: number,
+  ): Promise<Result<LangSmithPrompt[], PersistenceError>>;
+
+  /**
+   * Lists all versions of a specific prompt (if supported).
+   * Note: This might require additional API calls.
+   * @param promptName - The name of the prompt
+   * @returns Promise<Result<LangSmithPrompt[], PersistenceError>>
+   */
+  listPromptVersions?(
+    promptName: string,
+  ): Promise<Result<LangSmithPrompt[], PersistenceError>>;
+}
+
+/**
+ * Configuration for LangSmith client.
+ */
+export interface LangSmithConfig {
+  apiKey: string;
+  apiUrl?: string;
+  workspace?: string;
+}

--- a/packages/prompts/src/infrastructure/repositories/langsmith-prompt.repository.ts
+++ b/packages/prompts/src/infrastructure/repositories/langsmith-prompt.repository.ts
@@ -1,0 +1,390 @@
+import { Result } from "../../shared/types/result.js";
+import {
+  NotFoundError,
+  PersistenceError,
+} from "../../shared/errors/domain.errors.js";
+import {
+  PromptRepository,
+  PromptFilter,
+} from "../../domain/repositories/prompt.repository.js";
+import {
+  Prompt,
+  CreatePromptParams,
+} from "../../domain/entities/prompt.entity.js";
+import { PromptId } from "../../domain/value-objects/prompt-id.value-object.js";
+import { PromptCategory } from "../../domain/value-objects/prompt-metadata.value-object.js";
+import { LanguageCode } from "../../domain/value-objects/language-code.value-object.js";
+import {
+  PromptVariables,
+  VariableDefinition,
+} from "../../domain/value-objects/prompt-variables.value-object.js";
+import type {
+  LangSmithClient,
+  LangSmithPrompt,
+} from "../clients/langsmith-client.types.js";
+import type { Logger } from "@the-project-b/logging";
+
+/**
+ * Repository implementation for LangSmith prompt storage.
+ * Adapts LangSmith API to domain repository interface.
+ */
+export class LangSmithPromptRepository implements PromptRepository {
+  constructor(
+    private readonly client: LangSmithClient,
+    private readonly logger?: Logger,
+  ) {}
+
+  /**
+   * Converts a LangSmith prompt to domain Prompt entity.
+   * @param langsmithPrompt - The LangSmith prompt data
+   * @returns Result<Prompt, PersistenceError>
+   */
+  private convertToDomainPrompt(
+    langsmithPrompt: LangSmithPrompt,
+  ): Result<Prompt, PersistenceError> {
+    try {
+      // Log the incoming LangSmith prompt structure
+      this.logger?.info("Converting LangSmith prompt to domain", {
+        id: langsmithPrompt.id,
+        name: langsmithPrompt.name,
+        templateType: typeof langsmithPrompt.template,
+        isArray: Array.isArray(langsmithPrompt.template),
+        template: langsmithPrompt.template,
+        input_variables: langsmithPrompt.input_variables,
+        metadata: langsmithPrompt.metadata,
+      });
+
+      // Extract template based on type
+      let templateContent: string;
+      let variables: PromptVariables;
+
+      if (typeof langsmithPrompt.template === "string") {
+        templateContent = langsmithPrompt.template;
+      } else if (Array.isArray(langsmithPrompt.template)) {
+        // For chat prompts, use the system message or concatenate all
+        const systemMessage = langsmithPrompt.template.find(
+          (msg) => msg.role === "system",
+        );
+        templateContent =
+          systemMessage?.content ||
+          langsmithPrompt.template.map((msg) => msg.content).join("\n");
+      } else {
+        templateContent = JSON.stringify(langsmithPrompt.template);
+      }
+
+      // Extract variables from input_variables if available
+      if (
+        langsmithPrompt.input_variables &&
+        langsmithPrompt.input_variables.length > 0
+      ) {
+        const variableDefinitions: VariableDefinition[] = [];
+
+        for (const varName of langsmithPrompt.input_variables) {
+          variableDefinitions.push({
+            name: varName,
+            type: "string",
+            required: true,
+            description: `Variable ${varName} from LangSmith prompt`,
+          });
+        }
+
+        const variablesResult = PromptVariables.create(variableDefinitions);
+        if (Result.isFailure(variablesResult)) {
+          throw new Error(
+            `Failed to create variables: ${Result.unwrapFailure(variablesResult).message}`,
+          );
+        }
+        variables = Result.unwrap(variablesResult);
+      } else {
+        variables = PromptVariables.empty();
+      }
+
+      // Create prompt params
+      const createParams: CreatePromptParams = {
+        id: langsmithPrompt.id,
+        name: langsmithPrompt.name,
+        category: PromptCategory.SYSTEM, // Use SYSTEM category for LangSmith prompts
+        templates: {
+          [LanguageCode.getDefault().toString()]: templateContent,
+        },
+        variables,
+        metadata: {
+          version: langsmithPrompt.metadata?.version || "1.0.0",
+          tags: langsmithPrompt.metadata?.tags || [],
+          description: langsmithPrompt.description,
+        },
+      };
+
+      this.logger?.info("Creating domain prompt with params", {
+        id: createParams.id,
+        name: createParams.name,
+        category: createParams.category,
+        templatesKeys: Object.keys(createParams.templates),
+        hasVariables: !!createParams.variables,
+        metadata: createParams.metadata,
+      });
+
+      const promptResult = Prompt.create(createParams);
+
+      if (Result.isFailure(promptResult)) {
+        const error = Result.unwrapFailure(promptResult);
+        this.logger?.error("Failed to create domain prompt", {
+          error: error.message,
+          errorType: error.constructor.name,
+          errorDetails: error,
+        });
+        return Result.failure(
+          new PersistenceError(
+            `Failed to convert LangSmith prompt: ${error.message}`,
+          ),
+        );
+      }
+
+      this.logger?.debug("Successfully converted LangSmith prompt to domain", {
+        promptName: langsmithPrompt.name,
+      });
+
+      return Result.success(Result.unwrap(promptResult));
+    } catch (error) {
+      this.logger?.error("Failed to convert LangSmith prompt", {
+        error: error instanceof Error ? error.message : error,
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+      return Result.failure(
+        new PersistenceError(
+          `Failed to convert LangSmith prompt: ${error instanceof Error ? error.message : "Unknown error"}`,
+        ),
+      );
+    }
+  }
+
+  /**
+   * Finds a prompt by its unique identifier.
+   * @param id - The prompt ID to search for
+   * @returns Promise<Result<Prompt, NotFoundError>>
+   */
+  async findById(id: PromptId): Promise<Result<Prompt, NotFoundError>> {
+    const promptResult = await this.client.pullPrompt(id.toString());
+
+    if (Result.isFailure(promptResult)) {
+      return Result.failure(new NotFoundError("Prompt", id.toString()));
+    }
+
+    const langsmithPrompt = Result.unwrap(promptResult);
+    const domainPromptResult = this.convertToDomainPrompt(langsmithPrompt);
+
+    if (Result.isFailure(domainPromptResult)) {
+      return Result.failure(new NotFoundError("Prompt", id.toString()));
+    }
+
+    return Result.success(Result.unwrap(domainPromptResult));
+  }
+
+  /**
+   * Finds a prompt by its name.
+   * @param name - The prompt name to search for
+   * @returns Promise<Result<Prompt, NotFoundError>>
+   */
+  async findByName(name: string): Promise<Result<Prompt, NotFoundError>> {
+    const promptResult = await this.client.pullPrompt(name);
+
+    if (Result.isFailure(promptResult)) {
+      this.logger?.error("Failed to fetch prompt from LangSmith", {
+        name,
+        error: Result.unwrapFailure(promptResult),
+      });
+      return Result.failure(new NotFoundError("Prompt", name));
+    }
+
+    const langsmithPrompt = Result.unwrap(promptResult);
+    const domainPromptResult = this.convertToDomainPrompt(langsmithPrompt);
+
+    if (Result.isFailure(domainPromptResult)) {
+      this.logger?.error("Failed to convert LangSmith prompt to domain", {
+        name,
+        error: Result.unwrapFailure(domainPromptResult),
+      });
+      return Result.failure(new NotFoundError("Prompt", name));
+    }
+
+    return Result.success(Result.unwrap(domainPromptResult));
+  }
+
+  /**
+   * Gets the latest version of a prompt.
+   * @param name - The prompt name
+   * @returns Promise<Result<Prompt, NotFoundError>>
+   */
+  async getLatestVersion(name: string): Promise<Result<Prompt, NotFoundError>> {
+    return this.findByName(name);
+  }
+
+  /**
+   * Lists all versions of a prompt.
+   * @param name - The prompt name
+   * @returns Promise<Result<Prompt[], PersistenceError>>
+   */
+  async listVersions(
+    name: string,
+  ): Promise<Result<Prompt[], PersistenceError>> {
+    const versionsResult = await this.client.listPromptVersions(name);
+
+    if (Result.isFailure(versionsResult)) {
+      return Result.failure(
+        new PersistenceError(
+          `Failed to list versions: ${Result.unwrapFailure(versionsResult).message}`,
+        ),
+      );
+    }
+
+    const langsmithPrompts = Result.unwrap(versionsResult);
+    const domainPrompts: Prompt[] = [];
+
+    for (const langsmithPrompt of langsmithPrompts) {
+      const domainPromptResult = this.convertToDomainPrompt(langsmithPrompt);
+      if (Result.isSuccess(domainPromptResult)) {
+        domainPrompts.push(Result.unwrap(domainPromptResult));
+      }
+    }
+
+    return Result.success(domainPrompts);
+  }
+
+  /**
+   * Lists prompts with optional filtering.
+   * @param filter - Optional filter criteria
+   * @returns Promise<Result<Prompt[], PersistenceError>>
+   */
+  async list(
+    filter?: PromptFilter,
+  ): Promise<Result<Prompt[], PersistenceError>> {
+    const promptsResult = await this.client.listPrompts();
+
+    if (Result.isFailure(promptsResult)) {
+      return Result.failure(
+        new PersistenceError(
+          `Failed to list prompts: ${Result.unwrapFailure(promptsResult).message}`,
+        ),
+      );
+    }
+
+    const langsmithPrompts = Result.unwrap(promptsResult);
+    const domainPrompts: Prompt[] = [];
+
+    for (const langsmithPrompt of langsmithPrompts) {
+      const domainPromptResult = this.convertToDomainPrompt(langsmithPrompt);
+      if (Result.isSuccess(domainPromptResult)) {
+        const prompt = Result.unwrap(domainPromptResult);
+
+        // Apply filters if provided
+        if (filter) {
+          if (
+            filter.namePattern &&
+            !prompt.getName().includes(filter.namePattern)
+          ) {
+            continue;
+          }
+          if (
+            filter.category &&
+            prompt.getMetadata().getCategory() !== filter.category
+          ) {
+            continue;
+          }
+          if (filter.tags && filter.tags.length > 0) {
+            const promptTags = prompt.getMetadata().getTags();
+            if (!filter.tags.some((tag) => promptTags.includes(tag))) {
+              continue;
+            }
+          }
+        }
+
+        domainPrompts.push(prompt);
+      }
+    }
+
+    return Result.success(domainPrompts);
+  }
+
+  /**
+   * Finds prompts by category.
+   * @param category - The category to filter by
+   * @returns Promise<Result<Prompt[], PersistenceError>>
+   */
+  async findByCategory(
+    category: PromptCategory,
+  ): Promise<Result<Prompt[], PersistenceError>> {
+    return this.list({ category });
+  }
+
+  /**
+   * Finds prompts by tags.
+   * @param tags - Tags to search for
+   * @returns Promise<Result<Prompt[], PersistenceError>>
+   */
+  async findByTags(
+    tags: string[],
+  ): Promise<Result<Prompt[], PersistenceError>> {
+    return this.list({ tags });
+  }
+
+  /**
+   * Checks if a prompt exists by ID.
+   * @param id - The prompt ID to check
+   * @returns Promise<boolean>
+   */
+  async exists(id: PromptId): Promise<boolean> {
+    const result = await this.findById(id);
+    return Result.isSuccess(result);
+  }
+
+  /**
+   * Counts total prompts matching filter.
+   * @param filter - Optional filter criteria
+   * @returns Promise<Result<number, PersistenceError>>
+   */
+  async count(
+    filter?: PromptFilter,
+  ): Promise<Result<number, PersistenceError>> {
+    const listResult = await this.list(filter);
+    if (Result.isFailure(listResult)) {
+      return Result.failure(Result.unwrapFailure(listResult));
+    }
+    return Result.success(Result.unwrap(listResult).length);
+  }
+
+  // #region Not Supported Operations
+  /**
+   * Saves a prompt - not supported for LangSmith.
+   * LangSmith prompts should be managed through the LangSmith UI.
+   */
+  async save(_prompt: Prompt): Promise<Result<void, PersistenceError>> {
+    return Result.failure(
+      new PersistenceError("Cannot save prompts to LangSmith via repository"),
+    );
+  }
+
+  /**
+   * Updates a prompt - not supported for LangSmith.
+   * LangSmith prompts should be managed through the LangSmith UI.
+   */
+  async update(_prompt: Prompt): Promise<Result<void, PersistenceError>> {
+    return Result.failure(
+      new PersistenceError("Cannot update prompts in LangSmith via repository"),
+    );
+  }
+
+  /**
+   * Deletes a prompt - not supported for LangSmith.
+   * LangSmith prompts should be managed through the LangSmith UI.
+   */
+  async delete(
+    _id: PromptId,
+  ): Promise<Result<void, NotFoundError | PersistenceError>> {
+    return Result.failure(
+      new PersistenceError(
+        "Cannot delete prompts from LangSmith via repository",
+      ),
+    );
+  }
+  // #endregion
+}

--- a/packages/rita-graphs/src/services/prompts/prompt.registry.ts
+++ b/packages/rita-graphs/src/services/prompts/prompt.registry.ts
@@ -1,0 +1,99 @@
+import { promptService } from "./prompt.service.js";
+import { Result } from "@the-project-b/prompts";
+import { createLogger } from "@the-project-b/logging";
+
+const logger = createLogger({ service: "prompt-registry" });
+
+/**
+ * Registry for all prompts used in Rita graphs.
+ * Registers prompts in the in-memory repository for local development.
+ */
+export class PromptRegistry {
+  private static initialized = false;
+
+  /**
+   * Initialize all prompts in the registry.
+   * This should be called once during application startup.
+   */
+  static async initialize(): Promise<void> {
+    if (this.initialized) {
+      logger.debug("Prompt registry already initialized");
+      return;
+    }
+
+    logger.info("Initializing prompt registry");
+
+    // Register all prompts
+    await this.registerTitleGenerationPrompt();
+
+    this.initialized = true;
+    logger.info("Prompt registry initialized successfully");
+  }
+
+  /**
+   * Register the title generation prompt with language-specific templates.
+   */
+  private static async registerTitleGenerationPrompt(): Promise<void> {
+    const result = await promptService.registerPrompt({
+      name: "generate-title-system",
+      templates: {
+        EN: `You are a professional payroll system assistant. Generate a concise, descriptive title for this conversation.
+
+The user's preferred language is: {languageText}
+
+The title should:
+- Be maximum 50 characters
+- Summarize the main topic or request
+- Use professional, clear language
+- Be written in {languageText}
+- Be informative but NOT include specific numbers or amounts
+- Focus on the type of change or request, not the exact values
+
+Good examples in {languageText}:
+{examples}
+
+Conversation context (including initial request):
+{conversationContext}`,
+        DE: `Sie sind ein professioneller Assistent für Lohnabrechnungssysteme. Erstellen Sie einen prägnanten, beschreibenden Titel für diese Unterhaltung.
+
+Die bevorzugte Sprache des Benutzers ist: {languageText}
+
+Der Titel sollte:
+- Maximal 50 Zeichen lang sein
+- Das Hauptthema oder die Anfrage zusammenfassen
+- Professionelle, klare Sprache verwenden
+- In {languageText} geschrieben sein
+- Informativ sein, aber KEINE spezifischen Zahlen oder Beträge enthalten
+- Sich auf die Art der Änderung oder Anfrage konzentrieren, nicht auf die genauen Werte
+
+Gute Beispiele in {languageText}:
+{examples}
+
+Gesprächskontext (einschließlich der ersten Anfrage):
+{conversationContext}`,
+      },
+      metadata: {
+        description: "System prompt for generating conversation titles",
+        version: "1.0.0",
+        tags: ["title", "generation", "conversation"],
+      },
+      source: "memory",
+    });
+
+    if (Result.isFailure(result)) {
+      logger.error("Failed to register title generation prompt", {
+        error: Result.unwrapFailure(result),
+      });
+      throw Result.unwrapFailure(result);
+    }
+
+    logger.debug("Title generation prompt registered successfully");
+  }
+
+  /**
+   * Check if the registry has been initialized.
+   */
+  static isInitialized(): boolean {
+    return this.initialized;
+  }
+}

--- a/packages/rita-graphs/src/services/prompts/prompt.service.ts
+++ b/packages/rita-graphs/src/services/prompts/prompt.service.ts
@@ -1,0 +1,34 @@
+import {
+  PromptService,
+  InMemoryPromptRepository,
+  LangSmithPromptRepository,
+  LangSmithClientAdapter,
+} from "@the-project-b/prompts";
+import { createLogger } from "@the-project-b/logging";
+
+// Create logger
+const logger = createLogger({ service: "prompt-service" });
+
+// Initialize LangSmith client
+const langsmithClient = new LangSmithClientAdapter(
+  {
+    apiKey: process.env.LANGSMITH_API_KEY,
+    apiUrl: process.env.LANGSMITH_ENDPOINT,
+    workspace: process.env.LANGSMITH_PROJECT,
+  },
+  logger,
+);
+
+// Create repositories
+const memoryRepo = new InMemoryPromptRepository();
+const langsmithRepo = new LangSmithPromptRepository(langsmithClient, logger);
+
+// Initialize PromptService with multiple sources
+export const promptService = new PromptService({
+  repositories: {
+    memory: memoryRepo,
+    langsmith: langsmithRepo,
+  },
+  defaultSource: "memory", // Default to local during development
+  logger,
+});


### PR DESCRIPTION
- Completes PRO-7374

Example integration in node:

```typescript
import { GraphState } from "./types";

export async function routerNode(state: GraphState) {
  const promptService = getPromptService(); // Get singleton instance
  
  // Format prompt with LangSmith
  const promptResult = await promptService.formatPrompt({
    promptName: "router-system",
    source: "langsmith",
    variables: {
      userMessage: state.messages[state.messages.length - 1].content,
    },
    correlationId: state.runId,
  });
  
  if (Result.isFailure(promptResult)) {
    logger.error("Failed to format prompt", { 
      error: Result.unwrapFailure(promptResult) 
    });
    // Fallback to local prompt or handle error
    return state;
  }
  
  const formatted = Result.unwrap(promptResult);
  
  // Use the formatted prompt with your LLM
  const model = new ChatOpenAI({ temperature: 0 });
  const response = await model.invoke(formatted.content);
  
  return {
    ...state,
    route: parseRoute(response.content),
    metadata: {
      ...state.metadata,
      promptMetadata: formatted.metadata, // Preserve for tracing
    },
  };
}
```